### PR TITLE
Drop python 2.7 travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ jobs:
       before_install:
         - sudo apt-get update
         - sudo apt-get -y install python3-pyqt5
+      before_script:
+        - export PGMPL_TEST_VERBOSE=1
       services:
        - xvfb
 ##  This doesn't work because of a backwards-incompatible change in PyQt5, so pyqtgraph can't import sip from PyQt5

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ jobs:
     - name: "python 3.6 qt5 bionic pgmpl"
       dist: bionic
       python: 3.6
-        virtualenv:
-          system_site_packages: true
+      virtualenv:
+        system_site_packages: true
       before_install:
         - sudo apt-get update
         - sudo apt-get -y install python3-pyqt5

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,18 @@ jobs:
     - name: "python 3.6 qt5 bionic pgmpl"
       dist: bionic
       python: 3.6
+        virtualenv:
+          system_site_packages: true
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get -y install python3-pyqt5
+      services:
+       - xvfb
+    - name: "python 3.7 qt5 bionic pgmpl"
+      dist: bionic
+      python: 3.7
+        virtualenv:
+          system_site_packages: true
       before_install:
         - sudo apt-get update
         - sudo apt-get -y install python3-pyqt5
@@ -41,11 +53,19 @@ jobs:
         - sudo apt-get -y install python3-pyqt5
       services:
        - xvfb
+    - name: "python 3.9 qt5 bionic pgmpl"
+      dist: bionic
+      python: 3.9
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get -y install python3-pyqt5
+      services:
+       - xvfb
 
 # https://stackoverflow.com/a/35029430/6605826
 # system_site_packages limits py versions https://travis-ci.community/t/python-3-6-and-3-7-with-system-site-packages-enabled-fails-to-activate-on-xenial/1697
-virtualenv:
-  system_site_packages: true
+#virtualenv:
+#  system_site_packages: true
 
 # apt-get commands depend on py version: https://stackoverflow.com/a/20621143/6605826
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ jobs:
     - name: "python 3.6 qt5 bionic pgmpl"
       dist: bionic
       python: 3.6
+        virtualenv:
+          system_site_packages: true
       before_install:
         - sudo apt-get update
         - sudo apt-get -y install python3-pyqt5
@@ -41,11 +43,27 @@ jobs:
         - sudo apt-get -y install python3-pyqt5
       services:
        - xvfb
+    - name: "python 3.8 qt5 bionic pgmpl"
+      dist: bionic
+      python: 3.8
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get -y install python3-pyqt5
+      services:
+       - xvfb
+    - name: "python 3.9 qt5 bionic pgmpl"
+      dist: bionic
+      python: 3.9
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get -y install python3-pyqt5
+      services:
+       - xvfb
 
 # https://stackoverflow.com/a/35029430/6605826
 # system_site_packages limits py versions https://travis-ci.community/t/python-3-6-and-3-7-with-system-site-packages-enabled-fails-to-activate-on-xenial/1697
-virtualenv:
-  system_site_packages: true
+# virtualenv:
+#   system_site_packages: true
 
 # apt-get commands depend on py version: https://stackoverflow.com/a/20621143/6605826
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ jobs:
     - name: "python 3.6 qt5 bionic pgmpl"
       dist: bionic
       python: 3.6
-        virtualenv:
-          system_site_packages: true
       before_install:
         - sudo apt-get update
         - sudo apt-get -y install python3-pyqt5
@@ -38,24 +36,6 @@ jobs:
     - name: "python 3.7 qt5 bionic pgmpl"
       dist: bionic
       python: 3.7
-        virtualenv:
-          system_site_packages: true
-      before_install:
-        - sudo apt-get update
-        - sudo apt-get -y install python3-pyqt5
-      services:
-       - xvfb
-    - name: "python 3.8 qt5 bionic pgmpl"
-      dist: bionic
-      python: 3.8
-      before_install:
-        - sudo apt-get update
-        - sudo apt-get -y install python3-pyqt5
-      services:
-       - xvfb
-    - name: "python 3.9 qt5 bionic pgmpl"
-      dist: bionic
-      python: 3.9
       before_install:
         - sudo apt-get update
         - sudo apt-get -y install python3-pyqt5
@@ -64,8 +44,8 @@ jobs:
 
 # https://stackoverflow.com/a/35029430/6605826
 # system_site_packages limits py versions https://travis-ci.community/t/python-3-6-and-3-7-with-system-site-packages-enabled-fails-to-activate-on-xenial/1697
-#virtualenv:
-#  system_site_packages: true
+virtualenv:
+  system_site_packages: true
 
 # apt-get commands depend on py version: https://stackoverflow.com/a/20621143/6605826
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,32 +2,17 @@ language: python
 sudo: required
 jobs:
   include:
-    - name: "python 2.7 qt4 trusty pgmpl"
-      dist: trusty
-      python: 2.7
-#      virtualenv:
-#        system_site_packages: true
-      before_install:
-        - sudo apt-get update
-        - sudo apt-get -y install python-qt4
-      before_script:
-       # From pyqtgraph's .travis.yml: https://github.com/pyqtgraph/pyqtgraph/blob/develop/.travis.yml
-       # We need to create a (fake) display on Travis, let's use a funny resolution
-       - export DISPLAY=:99.0
-       - "sh -e /etc/init.d/xvfb start"
-       - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render
-       - export PGMPL_TEST_VERBOSE=1
-    - name: "python 2.7 qt5 bionic pgmpl"
-      dist: bionic
-      python: 2.7
-      before_install:
-        - sudo apt-get update
-        - sudo apt-get -y install python-pyqt5
-      services:
-       - xvfb
     - name: "python 3.6 qt5 bionic pgmpl"
       dist: bionic
       python: 3.6
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get -y install python3-pyqt5
+      services:
+       - xvfb
+    - name: "python 3.9 qt5 bionic pgmpl"
+      dist: bionic
+      python: 3.9
       before_install:
         - sudo apt-get update
         - sudo apt-get -y install python3-pyqt5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 sudo: required
 jobs:
   include:
+##   Python 2.7 tests are dropped because they are no longer important after py2 end of life
 #    - name: "python 2.7 qt4 trusty pgmpl"
 #      dist: trusty
 #      python: 2.7
@@ -17,6 +18,7 @@ jobs:
 #       - "sh -e /etc/init.d/xvfb start"
 #       - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render
 #       - export PGMPL_TEST_VERBOSE=1
+##   Python 2.7 tests are dropped because they are no longer important after py2 end of life
 #    - name: "python 2.7 qt5 bionic pgmpl"
 #      dist: bionic
 #      python: 2.7
@@ -33,14 +35,15 @@ jobs:
         - sudo apt-get -y install python3-pyqt5
       services:
        - xvfb
-    - name: "python 3.8 qt5 focal pgmpl"
-      dist: focal
-      python: 3.8
-      before_install:
-        - sudo apt-get update
-        - sudo apt-get -y install python3-pyqt5
-      services:
-       - xvfb
+##  This doesn't work because of a backwards-incompatible change in PyQt5, so pyqtgraph can't import sip from PyQt5
+#    - name: "python 3.8 qt5 focal pgmpl"
+#      dist: focal
+#      python: 3.8
+#      before_install:
+#        - sudo apt-get update
+#        - sudo apt-get -y install python3-pyqt5
+#      services:
+#       - xvfb
 
 # https://stackoverflow.com/a/35029430/6605826
 # system_site_packages limits py versions https://travis-ci.community/t/python-3-6-and-3-7-with-system-site-packages-enabled-fails-to-activate-on-xenial/1697

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,29 @@ language: python
 sudo: required
 jobs:
   include:
+#    - name: "python 2.7 qt4 trusty pgmpl"
+#      dist: trusty
+#      python: 2.7
+##      virtualenv:
+##        system_site_packages: true
+#      before_install:
+#        - sudo apt-get update
+#        - sudo apt-get -y install python-qt4
+#      before_script:
+#       # From pyqtgraph's .travis.yml: https://github.com/pyqtgraph/pyqtgraph/blob/develop/.travis.yml
+#       # We need to create a (fake) display on Travis, let's use a funny resolution
+#       - export DISPLAY=:99.0
+#       - "sh -e /etc/init.d/xvfb start"
+#       - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render
+#       - export PGMPL_TEST_VERBOSE=1
+#    - name: "python 2.7 qt5 bionic pgmpl"
+#      dist: bionic
+#      python: 2.7
+#      before_install:
+#        - sudo apt-get update
+#        - sudo apt-get -y install python-pyqt5
+#      services:
+#       - xvfb
     - name: "python 3.6 qt5 bionic pgmpl"
       dist: bionic
       python: 3.6
@@ -10,9 +33,9 @@ jobs:
         - sudo apt-get -y install python3-pyqt5
       services:
        - xvfb
-    - name: "python 3.9 qt5 bionic pgmpl"
+    - name: "python 3.8 qt5 bionic pgmpl"
       dist: bionic
-      python: 3.9
+      python: 3.8
       before_install:
         - sudo apt-get update
         - sudo apt-get -y install python3-pyqt5

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,32 +28,14 @@ jobs:
     - name: "python 3.6 qt5 bionic pgmpl"
       dist: bionic
       python: 3.6
-      virtualenv:
-        system_site_packages: true
       before_install:
         - sudo apt-get update
         - sudo apt-get -y install python3-pyqt5
       services:
        - xvfb
-    - name: "python 3.7 qt5 bionic pgmpl"
-      dist: bionic
-      python: 3.7
-      before_install:
-        - sudo apt-get update
-        - sudo apt-get -y install python3-pyqt5
-      services:
-       - xvfb
-    - name: "python 3.8 qt5 bionic pgmpl"
-      dist: bionic
+    - name: "python 3.8 qt5 focal pgmpl"
+      dist: focal
       python: 3.8
-      before_install:
-        - sudo apt-get update
-        - sudo apt-get -y install python3-pyqt5
-      services:
-       - xvfb
-    - name: "python 3.9 qt5 bionic pgmpl"
-      dist: bionic
-      python: 3.9
       before_install:
         - sudo apt-get update
         - sudo apt-get -y install python3-pyqt5
@@ -62,8 +44,8 @@ jobs:
 
 # https://stackoverflow.com/a/35029430/6605826
 # system_site_packages limits py versions https://travis-ci.community/t/python-3-6-and-3-7-with-system-site-packages-enabled-fails-to-activate-on-xenial/1697
-# virtualenv:
-#   system_site_packages: true
+virtualenv:
+  system_site_packages: true
 
 # apt-get commands depend on py version: https://stackoverflow.com/a/20621143/6605826
 install:


### PR DESCRIPTION
Description:
- Change test setups in .travis.yml to drop python 2.7 tests
- Tried to add more python3 versions
  - But getting PyQt5 to work is hard unless the python version in use is the one that ships with the OS, so ubuntu bionic beaver has to use 3.6, focal fossa has to use 3.8, etc.
  - Turns out that the newer PyQt5 that ships with py3.8 is not backward compatible with what pyqtgraph needs, so it fails.

Pre-merge checklist (in addition to automatic checks):
- [x] Author has reviewed and finalized code
- [x] New functions, classes, and keywords are described in docstrings
- [x] This pull request is ready for review / merge
